### PR TITLE
Clean up

### DIFF
--- a/racket/monad-transformers.rkt
+++ b/racket/monad-transformers.rkt
@@ -19,7 +19,7 @@
 ; monoid (O : type) : type
 ; ozero : O
 ; oplus : O,O → O
-(define-struct monoid (ozero oplus))
+(struct monoid (ozero oplus) #:transparent)
 
 (define ((monoid-oconcat O) os)
   (sequence-fold (monoid-oplus O) (monoid-ozero O) os))
@@ -40,7 +40,7 @@
 ; effects : effect-name ⇰ effect-for(effect-name)
 ; effect-name ∈ {reader, writer, state, nondet}
 ; effect-for : effect-name → type
-(define-struct monad (return bind effects properties))
+(struct monad (return bind effects properties) #:transparent)
 
 ;;;;;;;;;;;
 ; Effects ;
@@ -52,25 +52,25 @@
 ; monad-reader (r : type) (M : type → type) : type
 ; ask : M(r)
 ; local-env : ∀a, r,M(a) → M(a)
-(define-struct monad-reader (ask local-env))
+(struct monad-reader (ask local-env) #:transparent)
 
 ; effect-for(writer) = monad-writer
 ; monad-writer (o : type) (M : type → type) : type
 ; tell : o → M(unit)
 ; hijack : ∀a, M(a) → M(a,o)
-(define-struct monad-writer (tell hijack))
+(struct monad-writer (tell hijack) #:transparent)
 
 ; effect-for(state) = monad-state
 ; monad-state (s : type) (M : type → type) : type
 ; get : M(s)
 ; put : s → M(unit)
-(define-struct monad-state (get put))
+(struct monad-state (get put) #:transparent)
 
 ; effect-for(nondet) = monad-nondet
 ; nondet (M : type → type) : type
 ; mzero : ∀a, M(a)
 ; mplus : ∀a, M(a),M(a) → M(a)
-(define-struct monad-nondet (mzero mplus))
+(struct monad-nondet (mzero mplus) #:transparent)
 
 ;;;;;;;;;;
 ; Syntax ;
@@ -85,8 +85,7 @@
                    [oplus (format-id #'e "oplus")]
                    [oconcat (format-id #'e "oconcat")])
        #'(local [(define O′ O)
-                 (define ozero (monoid-ozero O′))
-                 (define oplus (monoid-oplus O′))
+                 (match-define (monoid ozero oplus) O′)
                  (define oconcat (monoid-oconcat O′))]
            e))]))
 ; `(with-monad M e)` introduces monad operations and do notation into scope
@@ -108,27 +107,21 @@
                    [mplus (format-id #'e "mplus")]
                    [monoid-functor (format-id #'e "monoid-functor")])
        #'(local [(define M′ M)
-                 (define return (monad-return M′))
-                 (define bind (monad-bind M′))
+                 (match-define (monad return bind effects properties) M′)
                  (define-syntax do
                    (syntax-rules (←)
                      [(do xM) xM]
                      [(do p ← xM . bs)
-                      (bind xM (λ (x) 
-                                  (match-let [(p x)]
-                                    (do . bs))))]
+                      (bind xM (match-lambda
+                                 [p (do . bs)]))]
                      [(do xM . bs)
                       (bind xM (λ (x)
-                                  (do . bs)))]))
-                 (define monoid-functor (dict-ref (monad-properties M′) 'monoid-functor false))
-                 (define ask       (monad-reader-ask       (dict-ref (monad-effects M′) 'reader (make-monad-reader false false))))
-                 (define local-env (monad-reader-local-env (dict-ref (monad-effects M′) 'reader (make-monad-reader false false))))
-                 (define tell      (monad-writer-tell      (dict-ref (monad-effects M′) 'writer (make-monad-writer false false))))
-                 (define hijack    (monad-writer-hijack    (dict-ref (monad-effects M′) 'writer (make-monad-writer false false))))
-                 (define get       (monad-state-get        (dict-ref (monad-effects M′) 'state  (make-monad-state false false))))
-                 (define put       (monad-state-put        (dict-ref (monad-effects M′) 'state  (make-monad-state false false))))
-                 (define mzero     (monad-nondet-mzero     (dict-ref (monad-effects M′) 'nondet (make-monad-nondet false false))))
-                 (define mplus     (monad-nondet-mplus     (dict-ref (monad-effects M′) 'nondet (make-monad-nondet false false))))]
+                                 (do . bs)))]))
+                 (define monoid-functor (hash-ref properties 'monoid-functor #f))
+                 (match-define (monad-reader ask local-env) (hash-ref effects 'reader (monad-reader #f #f)))
+                 (match-define (monad-writer tell hijack) (hash-ref effects 'writer (monad-writer #f #f)))
+                 (match-define (monad-state get put) (hash-ref effects 'state  (monad-state #f #f)))
+                 (match-define (monad-nondet mzero mplus) (hash-ref effects 'nondet (monad-nondet #f #f)))]
            e))]))
 
 ;;;;;;;;;;;;;
@@ -137,7 +130,7 @@
 
 ; Powerset Commutative Monoid
 (define PowerO
-  (make-monoid
+  (monoid
     ; ozero
     (set)
     ; oplus
@@ -145,7 +138,7 @@
 
 ; Addition Commutative Monoid
 (define AddO
-  (make-monoid 
+  (monoid 
     ; ozero
     0 
     ; oplus
@@ -153,7 +146,7 @@
 
 ; Pair Monoid
 (define (PairO O₁ O₂)
-  (make-monoid
+  (monoid
     ; ozero
     (cons (with-monoid O₁ ozero) (with-monoid O₂ ozero))
     ; oplus
@@ -168,7 +161,7 @@
 ;;;;;;;;;;;;;;;;;;
 
 ; ID a ≔ a
-(define ID (make-monad
+(define ID (monad
              (λ (x) x)
              (λ (xM f) (f xM))
              (hash)
@@ -192,7 +185,7 @@
   (xM r))
 (define (ReaderT M)
   (with-monad M
-    (make-monad
+    (monad
       ; return
       (λ (x)
          (λ (r)
@@ -207,7 +200,7 @@
       ((compose
          (if (not (hash-has-key? (monad-effects M) 'reader))
            ; the standard reader effect
-           (λ (h) (hash-set h 'reader (make-monad-reader
+           (λ (h) (hash-set h 'reader (monad-reader
                                          ; ask
                                          (λ (r)
                                             (return r))
@@ -217,7 +210,7 @@
                                                (xM r′))))))
            ; combining with an underlying reader effect, resulting in a reader
            ; effect of pairs: (ReaderT r₁ ∘ ReaderT r₂) = ReaderT (r₁,r₂)
-           (λ (h) (hash-set h 'reader (make-monad-reader
+           (λ (h) (hash-set h 'reader (monad-reader
                                          ; ask
                                          (λ (r)
                                             (do
@@ -230,7 +223,7 @@
                                                  (local-env rₘ′ (xM r′)))))))))
          (if (not (hash-has-key? (monad-effects M) 'writer)) (λ (h) h)
            ; propagating writer effects
-           (λ (h) (hash-set h 'writer (make-monad-writer
+           (λ (h) (hash-set h 'writer (monad-writer
                                          ; tell
                                          (λ (o)
                                            (λ (r)
@@ -240,7 +233,7 @@
                                             (λ (r) (hijack (xM r))))))))
          (if (not (hash-has-key? (monad-effects M) 'state)) (λ (h) h)
            ; propagating state effects
-           (λ (h) (hash-set h 'state (make-monad-state
+           (λ (h) (hash-set h 'state (monad-state
                                         ; get
                                         (λ (r)
                                            get)
@@ -250,7 +243,7 @@
                                               (put s)))))))
          (if (not (hash-has-key? (monad-effects M) 'nondet)) (λ (h) h)
            ; propagating nondet effects
-           (λ (h) (hash-set h 'nondet (make-monad-nondet
+           (λ (h) (hash-set h 'nondet (monad-nondet
                                          ; mzero
                                          (λ (r) mzero)
                                          ; mplus
@@ -263,7 +256,7 @@
            ; propagating monoid functor
            (λ (h) (hash-set h 'monoid-functor (λ (O)
                                                 (with-monoid (monoid-functor O)
-                                                  (make-monoid
+                                                  (monoid
                                                     ; ozero
                                                     (λ (r) ozero)
                                                     ; oplus
@@ -310,7 +303,7 @@
   (check-equal?
     (run-StateT 10
       (run-ReaderT 1
-        (with-monad (ReaderT (StateT false ID))
+        (with-monad (ReaderT (StateT #f ID))
           (do
             x ← ask
             y ← get
@@ -336,7 +329,7 @@
 (define (WriterT O M)
   (with-monad M
     (with-monoid O
-      (make-monad
+      (monad
         ; return
         (λ (x)
            (return (cons x ozero)))
@@ -350,7 +343,7 @@
         ((compose
            (if (not (hash-has-key? (monad-effects M) 'reader)) (λ (h) h)
              ; propagating reader effects
-             (λ (h) (hash-set h 'reader (make-monad-reader
+             (λ (h) (hash-set h 'reader (monad-reader
                                            ; ask
                                            (do
                                              r ← ask
@@ -360,7 +353,7 @@
                                               (local-env r xM))))))
            (if (not (hash-has-key? (monad-effects M) 'writer))
              ; the standard writer effect
-             (λ (h) (hash-set h 'writer (make-monad-writer
+             (λ (h) (hash-set h 'writer (monad-writer
                                            ; tell
                                            (λ (o)
                                               (return (cons (void) o)))
@@ -371,7 +364,7 @@
                                                 (return (cons (cons x o) ozero)))))))
              ; combining with an underlying writer effect, resulting in a
              ; writer effect of pairs: (WriterT o₁ ∘ WriterT o₂) = WriterT (o₁,o₂)
-             (λ (h) (hash-set h 'writer (make-monad-writer
+             (λ (h) (hash-set h 'writer (monad-writer
                                            ; tell
                                            (λ (ooₘ)
                                               (match-let ([(cons o oₘ) ooₘ])
@@ -385,7 +378,7 @@
                                                 (return (cons (cons x (cons o oₘ)) ozero))))))))
            (if (not (hash-has-key? (monad-effects M) 'state)) (λ (h) h)
              ; propagating state effects
-             (λ (h) (hash-set h 'state (make-monad-state
+             (λ (h) (hash-set h 'state (monad-state
                                           ; get
                                           (do
                                             s ← get
@@ -397,7 +390,7 @@
                                                (return (cons (void) ozero))))))))
            (if (not (hash-has-key? (monad-effects M) 'nondet)) (λ (h) h)
              ; propagating nondet effects
-             (λ (h) (hash-set h 'nondet (make-monad-nondet
+             (λ (h) (hash-set h 'nondet (monad-nondet
                                            ; mzero
                                            mzero
                                            ; mplus
@@ -443,7 +436,7 @@
   ; WriterT(StateT(ID))(a) = s → ((a,o),s)
   (check-equal?
     (run-StateT 1
-      (with-monad (WriterT AddO (StateT false ID))
+      (with-monad (WriterT AddO (StateT #f ID))
         (do
           x ← get
           (tell x)
@@ -472,7 +465,7 @@
   (xM s))
 (define (StateT O M)
   (with-monad M
-  (make-monad
+  (monad
     ; return
     (λ (x)
        (λ (s) 
@@ -487,7 +480,7 @@
     ((compose
        (if (not (hash-has-key? (monad-effects M) 'reader)) (λ (h) h)
          ; propagating reader effects
-         (λ (h) (hash-set h 'reader (make-monad-reader
+         (λ (h) (hash-set h 'reader (monad-reader
                                        ; ask
                                        (λ (s)
                                           (do
@@ -498,7 +491,7 @@
                                           (λ (s) (local-env r (xM s))))))))
        (if (not (hash-has-key? (monad-effects M) 'writer)) (λ (h) h)
          ; propagating writer effects
-         (λ (h) (hash-set h 'writer (make-monad-writer
+         (λ (h) (hash-set h 'writer (monad-writer
                                        ; tell
                                        (λ (o)
                                           (λ (s)
@@ -513,7 +506,7 @@
                                                (return (cons (cons x o) s′)))))))))
        (if (not (hash-has-key? (monad-effects M) 'state))
          ; the standard state effect
-         (λ (h) (hash-set h 'state (make-monad-state
+         (λ (h) (hash-set h 'state (monad-state
                                       ; get
                                       (λ (s)
                                          (return (cons s s)))
@@ -523,7 +516,7 @@
                                             (return (cons (void) s′)))))))
          ; combining with an underlying state effect, resulting in a state
          ; effect of pairs: (StateT s₁ ∘ StateT s₂) = StateT (s₁,s₂)
-         (λ (h) (hash-set h 'state (make-monad-state
+         (λ (h) (hash-set h 'state (monad-state
                                       ; get
                                       (λ (s₁)
                                          (do
@@ -538,7 +531,7 @@
                                                 (return (cons (void) s₁′))))))))))
        (if (not (hash-has-key? (monad-effects M) 'nondet)) (λ (h) h)
          ; propagating nondet effects
-         (λ (h) (hash-set h 'nondet (make-monad-nondet
+         (λ (h) (hash-set h 'nondet (monad-nondet
                                        ; mzero
                                        (λ (s) mzero)
                                        ; mplus
@@ -554,7 +547,7 @@
          ; propagating monoid functor
          (λ (h) (hash-set h 'monoid-functor (λ (O′) 
                                               (with-monoid (monoid-functor (PairO O O′))
-                                                (make-monoid
+                                                (monoid
                                                   ; ozero
                                                   (λ (s) ozero)
                                                   ; oplus
@@ -566,7 +559,7 @@
 (module+ test
   ; StateT(ID)(a) = s → (a,s)
   (check-equal?
-    (with-monad (StateT false ID)
+    (with-monad (StateT #f ID)
       (run-StateT 1
         (do
           x ← get
@@ -585,7 +578,7 @@
 (define (NondetT M)
   (with-monad M
     (with-monoid (monoid-functor PowerO)
-      (make-monad
+      (monad
         ; return
         (λ (x)
            (return (set x)))
@@ -598,7 +591,7 @@
         ((compose
            (if (not (hash-has-key? (monad-effects M) 'reader)) (λ (h) h)
              ; propagating reader effects
-             (λ (h) (hash-set h 'reader (make-monad-reader
+             (λ (h) (hash-set h 'reader (monad-reader
                                            ; ask
                                            (do
                                              r ← ask
@@ -608,7 +601,7 @@
                                              (local-env r xM))))))
            (if (not (hash-has-key? (monad-effects M) 'writer)) (λ (h) h)
              ; propagating writer effects
-             (λ (h) (hash-set h 'writer (make-monad-writer
+             (λ (h) (hash-set h 'writer (monad-writer
                                            ; tell
                                            (λ (o)
                                               (do
@@ -621,7 +614,7 @@
                                                 (return (set-map xs (λ (x) (cons x o))))))))))
            (if (not (hash-has-key? (monad-effects M) 'state)) (λ (h) h)
              ; propagating state effects
-             (λ (h) (hash-set h 'state (make-monad-state
+             (λ (h) (hash-set h 'state (monad-state
                                           ; get
                                           (do
                                             s ← get
@@ -633,7 +626,7 @@
                                                (return (set (void)))))))))
            ; the standard nondet effect
            (λ (h) (hash-set h 'nondet
-                            (make-monad-nondet
+                            (monad-nondet
                               ; mzero
                               ozero
                               ; mplus


### PR DESCRIPTION
- use `struct` instead of `define-struct`
- use pattern matching where possible
- `false` -> `#f`
