### PR TITLE
Fix typos

### DIFF
--- a/monadic-eval/paper/04-cache.scrbl
+++ b/monadic-eval/paper/04-cache.scrbl
@@ -34,7 +34,7 @@ sets of value-and-store pairs (@racket[v×σ]). When a configuration is
 reached for the second time, rather than re-evaluating the expression
 and entering an infinite loop, the result is looked up from
 @racket[$in], which acts as an oracle. It is important that the cache
-is used in a @emph{productive} way: it is only safe to use @racket[in] as an
+is used in a @emph{productive} way: it is only safe to use @racket[$in] as an
 oracle so long as some progress has been made first.
 
 The results of evaluation are then stored in an output cache
@@ -42,7 +42,7 @@ The results of evaluation are then stored in an output cache
 than the input cache (@racket[$in]), again following a co-inductive
 argument. The least fixed-point @racket[$⁺] of an evaluator which
 transforms an oracle @racket[$in] and outputs a more defined oracle
-$racket[out] is then a sound approximation of the program, because it
+@racket[out] is then a sound approximation of the program, because it
 over-approximates all finite unrollings of the unfixed evaluator.
 
 The co-inductive caching algorithm is shown in @Figure-ref{f:caching},

--- a/monadic-eval/paper/08-symbolic-execution.scrbl
+++ b/monadic-eval/paper/08-symbolic-execution.scrbl
@@ -78,7 +78,7 @@ include symbolic numbers:
                
 
 
-@Figure-ref{f:symbolic-widen} shows the units needed to turn the
+@Figure-ref{f:symbolic} shows the units needed to turn the
 existing interpreter into a symbolic executor. Primitives such as
 @racket['/] now also take as input and return symbolic values. As
 standard, symbolic execution employs a path-condition accumulating


### PR DESCRIPTION
1. The cache name is `$in`, not `in`.
2. The escape character in Scribble is `@`, not `$`.
3. The Figure in question is 10, not 11.

(It’s kind of funny that 2 made into the paper. At first I was wondering
if you had used Scribble, but at that point I was sure, even before
looking at the sources 😛)

There’s actually a fourth bug: on § 10, there’s a psychologically bad
line break [1] before the reference [King 1976]. Unfortunately, I don’t
know how to fix this in Scribble. A hint might be the name of the
citation form, `~cite`, which seems to indicate that it inserts a
non-breaking space before the citation (in TeX, a non-breaking space is
spelled `~`, hence my intuition). If this is right, then the solution is
simple: everywhere this form is used, remove the space right before it,
for example, `closely@~cite{dvanhorn:King1976Symbolic}`.

This was an interesting and fun paper to read. Thank you for your work.

[1]: The TeXbook. Donald Ervin Knuth.